### PR TITLE
Add hover styles to saved cover view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,31 @@ body {
   justify-content: space-around;
 }
 
+.saved-covers-section {
+  visibility: hidden;
+}
+/* Prevents :hover from triggering in the gaps between items */
+
+.saved-covers-section > * {
+  visibility: visible;
+}
+/* Brings the child items back in, even though the parent is `hidden` */
+
+.saved-covers-section > * {
+  transition: opacity 150ms linear 100ms, transform 150ms ease-in-out 100ms;
+}
+/* Makes the fades smooth with a slight delay to prevent jumps as the mouse moves between items */
+
+.saved-covers-section:hover > * {
+  opacity: 0.4; transform: scale(0.9);
+}
+/* Fade out all items when the parent is hovered */
+
+.saved-covers-section > *:hover {
+  opacity: 1; transform: scale(1.1); transition-delay: 0ms, 0ms;
+}
+/* Fade in the currently hovered item */
+
 .mini-cover {
   height: 40vh;
   margin: 1.3vh auto;


### PR DESCRIPTION
- Hover feature has been added to the View Saved Covers section. The cover being hovered over grows slightly and a layer of opacity is added to the other covers to further accentuate the one under the mouse.
- This is a new feature.
- To review the code, check out the stylesheet.
- To test, add covers to the saved books section and view.