### PR TITLE
Delete comments from hover styles in CSS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -113,27 +113,22 @@ body {
 .saved-covers-section {
   visibility: hidden;
 }
-/* Prevents :hover from triggering in the gaps between items */
 
 .saved-covers-section > * {
   visibility: visible;
 }
-/* Brings the child items back in, even though the parent is `hidden` */
 
 .saved-covers-section > * {
   transition: opacity 150ms linear 100ms, transform 150ms ease-in-out 100ms;
 }
-/* Makes the fades smooth with a slight delay to prevent jumps as the mouse moves between items */
 
 .saved-covers-section:hover > * {
   opacity: 0.4; transform: scale(0.9);
 }
-/* Fade out all items when the parent is hovered */
 
 .saved-covers-section > *:hover {
   opacity: 1; transform: scale(1.1); transition-delay: 0ms, 0ms;
 }
-/* Fade in the currently hovered item */
 
 .mini-cover {
   height: 40vh;

--- a/styles.css
+++ b/styles.css
@@ -123,11 +123,14 @@ body {
 }
 
 .saved-covers-section:hover > * {
-  opacity: 0.4; transform: scale(0.9);
+  opacity: 0.4;
+  transform: scale(0.9);
 }
 
 .saved-covers-section > *:hover {
-  opacity: 1; transform: scale(1.1); transition-delay: 0ms, 0ms;
+  opacity: 1;
+  transform: scale(1.1);
+  transition-delay: 0ms, 0ms;
 }
 
 .mini-cover {


### PR DESCRIPTION
- Deleted the comments from the CSS file under the hover classes
- this is a fix
- Look over the styles for the mini-book classes, make sure there aren't any comments left in