### PR TITLE
Fix title and descriptors to pull random entries if blank

### DIFF
--- a/src/Cover.js
+++ b/src/Cover.js
@@ -2,8 +2,8 @@ class Cover {
   constructor(coverImgSrc, title, descriptor1, descriptor2) {
     this.id = Date.now();
     this.cover = coverImgSrc || 'http://placeimg.com/640/480/any';
-    this.title = title;
-    this.tagline1 = descriptor1;
-    this.tagline2 = descriptor2;
+    this.title = title || titles[getRandomIndex(titles)];
+    this.tagline1 = descriptor1 || descriptors[getRandomIndex(descriptors)];
+    this.tagline2 = descriptor2 || descriptors[getRandomIndex(descriptors)];
   }
 }


### PR DESCRIPTION
Fixed the Cover class to pull random entries from the relevant data asset arrays if the user left the input form blank.
This is a new feature
Test by using the custom input form and leaving entries blank. 