### PR TITLE
Fix mini-cover distressed overlay in save view

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -89,7 +89,7 @@ function createHTML() {
   <h2 class="cover-title">${currentCover.title}</h2>
   <h3 class="tagline">A tale of ${currentCover.tagline1} and ${currentCover.tagline2}<h3>
   <img class="price-tag" src="./assets/price.png">
-  <img class="overlay" src="./assets/overlay.png">
+  <img class="overlay mini-overlay" src="./assets/overlay.png">
   </div>`;
   savedCoverSection.insertAdjacentHTML('afterbegin', htmlBlock);
 }

--- a/styles.css
+++ b/styles.css
@@ -140,6 +140,10 @@ body {
   width: 14vw;
 }
 
+.mini-overlay {
+  top: 10.5px
+}
+
 .mini-cover > .cover-title {
   bottom: 45px;
   font-size: 40px;


### PR DESCRIPTION
What is the change?
- Added a mini-overlay class and CSS rule with a top of 10px to correct the fit of the "distressed" layer.
- This is a fix.
- To review, check out the new rule and the class added to the html code block added when a cover is saved.
- Test by saving books and making sure the overlay lines up in the saved covers view.